### PR TITLE
Add TIL landing page, starter TIL post, and navbar link

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -25,6 +25,7 @@ website:
   navbar:
     background: none
     right:
+      - til.qmd
       - tools.qmd
       - about.qmd
       - now.qmd

--- a/posts/til-first-til/index.qmd
+++ b/posts/til-first-til/index.qmd
@@ -1,0 +1,9 @@
+---
+title: "TIL: Quarto listing pages can be category-filtered"
+author: "VB"
+date: "2025-02-14"
+description: "Use Quarto listings with a category filter to build a TIL index."
+categories: [til, quarto]
+---
+
+Quarto listings can be filtered by category (e.g., `filter: "til"`) to create a dedicated TIL index while keeping everything in a single `posts/` collection.

--- a/posts/til-first-til/index.qmd
+++ b/posts/til-first-til/index.qmd
@@ -1,9 +1,0 @@
----
-title: "TIL: Quarto listing pages can be category-filtered"
-author: "VB"
-date: "2025-02-14"
-description: "Use Quarto listings with a category filter to build a TIL index."
-categories: [til, quarto]
----
-
-Quarto listings can be filtered by category (e.g., `filter: "til"`) to create a dedicated TIL index while keeping everything in a single `posts/` collection.

--- a/posts/til/quarto-listing-category-filter/index.qmd
+++ b/posts/til/quarto-listing-category-filter/index.qmd
@@ -1,0 +1,9 @@
+---
+title: "TIL: Quarto listing pages can target a subfolder"
+author: "VB"
+date: "2024-08-15"
+description: "Point a Quarto listing at a subfolder to build a focused TIL index."
+categories: [til, quarto, publishing]
+---
+
+Quarto listings can target a subfolder (like `posts/til`) to build a dedicated TIL index while keeping everything under the main `posts/` collection.

--- a/til.qmd
+++ b/til.qmd
@@ -2,10 +2,9 @@
 title: "TIL"
 description: "Short notes and things I learned."
 listing:
-  contents: posts
+  contents: posts/til
   sort: "date desc"
   categories: true
-  filter: "til"
   sort-ui: false
   filter-ui: false
   feed: true

--- a/til.qmd
+++ b/til.qmd
@@ -1,0 +1,16 @@
+---
+title: "TIL"
+description: "Short notes and things I learned."
+listing:
+  contents: posts
+  sort: "date desc"
+  categories: true
+  filter: "til"
+  sort-ui: false
+  filter-ui: false
+  feed: true
+page-layout: full
+title-block-banner: true
+---
+
+A running list of short notes and learnings, inspired by Simon Willison's TILs.


### PR DESCRIPTION
### Motivation
- Provide a dedicated TIL index that surfaces short "today I learned" notes filtered from the main `posts/` collection.
- Seed the TIL index with a starter entry to demonstrate the listing behavior and metadata conventions.
- Make the TIL page discoverable by exposing it in the site navbar. 
- Keep content organized while retaining a single `posts/` collection for all posts.

### Description
- Added `til.qmd` which defines a Quarto listing that filters `contents: posts` by `filter: "til"` and enables `feed: true` and `categories: true`.
- Added a starter post at `posts/til-first-til/index.qmd` with front-matter `categories: [til, quarto]` and a brief explanatory body.
- Updated `_quarto.yml` to include `til.qmd` in `website.navbar.right` so the TIL page appears in the site navigation.

### Testing
- No automated tests were executed because this is a content-only change.
- Changes were committed locally and are ready for CI to run on the pull request if configured.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69502a7fbdfc8328bc58fc067d446f24)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces a dedicated TIL section with a listings page, starter post, and navigation entry.
> 
> - Adds `til.qmd` listing (`contents: posts/til`, `categories: true`, RSS feed `til.xml`)
> - Adds folder defaults in `posts/til/_metadata.yml`
> - Seeds first TIL at `posts/til/quarto-listing-category-filter/index.qmd`
> - Updates `_quarto.yml` navbar to link `til.qmd`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 319af1ef353e31a3b402db3bad8fa324bdcef5b2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->